### PR TITLE
Add React Flow dialog editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # DialogTool
-browser-based tool for creating dialogs
+
+A browser-based dialog editor using React Flow. It loads dialog data from `data/dialog.json` and allows you to visually edit nodes and choices. Select a node to edit speaker, text, and choices in the sidebar. Add new nodes or download the dialog as JSON.
+
+Open `index.html` in a browser to start editing.

--- a/data/dialog.json
+++ b/data/dialog.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "start",
+    "speaker": "Overlord",
+    "text": "14195, do you hear me?",
+    "choices": [
+      { "text": "Hmmm...", "next": "resp1" },
+      { "text": "Where am I?", "next": "resp2" },
+      { "text": "Ah! A talking eyeball!", "next": "resp3" }
+    ]
+  },
+  {
+    "id": "resp1",
+    "speaker": "Overlord",
+    "text": "Good, you are awake.",
+    "next": "afterIntro"
+  },
+  {
+    "id": "resp2",
+    "speaker": "Overlord",
+    "text": "You are in my domain.",
+    "next": "afterIntro"
+  },
+  {
+    "id": "resp3",
+    "speaker": "Overlord",
+    "text": "Yes, I am more than just an eyeball.",
+    "next": "afterIntro"
+  },
+  {
+    "id": "afterIntro",
+    "speaker": "Overlord",
+    "text": "You have been revived for a critical task: the city is in danger and needs your help..."
+  }
+]

--- a/editor.js
+++ b/editor.js
@@ -1,0 +1,173 @@
+const {
+  ReactFlow: ReactFlowComponent,
+  addEdge,
+  MiniMap,
+  Controls,
+  Background,
+  ReactFlowProvider,
+  useNodesState,
+  useEdgesState
+} = window.ReactFlow;
+
+function scriptToFlow(script) {
+  const nodes = [];
+  const edges = [];
+  script.forEach((node, idx) => {
+    nodes.push({
+      id: node.id,
+      position: { x: idx * 200, y: idx * 80 },
+      data: { speaker: node.speaker || '', text: node.text || '' }
+    });
+    if (node.next) {
+      edges.push({ id: `${node.id}-${node.next}`, source: node.id, target: node.next, label: '' });
+    }
+    if (node.choices) {
+      node.choices.forEach((c, i) => {
+        edges.push({ id: `${node.id}-c${i}`, source: node.id, target: c.next, label: c.text });
+      });
+    }
+  });
+  return [nodes, edges];
+}
+
+function flowToScript(nodes, edges) {
+  const out = [];
+  const edgesBySource = {};
+  edges.forEach(e => {
+    if (!edgesBySource[e.source]) edgesBySource[e.source] = [];
+    edgesBySource[e.source].push(e);
+  });
+  nodes.forEach(n => {
+    const obj = { id: n.id, speaker: n.data.speaker, text: n.data.text };
+    const outs = edgesBySource[n.id] || [];
+    const choices = outs.filter(e => e.label);
+    if (choices.length) {
+      obj.choices = choices.map(e => ({ text: e.label, next: e.target }));
+    } else if (outs.length === 1) {
+      obj.next = outs[0].target;
+    }
+    out.push(obj);
+  });
+  return out;
+}
+
+function validate(nodes, edges, startId) {
+  const bySource = {};
+  edges.forEach(e => {
+    if (!bySource[e.source]) bySource[e.source] = [];
+    bySource[e.source].push(e.target);
+  });
+  const visited = new Set([startId]);
+  const q = [startId];
+  while (q.length) {
+    const id = q.shift();
+    const nexts = bySource[id] || [];
+    if (nexts.length === 0) return true;
+    nexts.forEach(n => { if (!visited.has(n)) { visited.add(n); q.push(n); } });
+  }
+  return false;
+}
+
+function NodeEditor({ node, nodes, edges, updateNode, addChoice, removeEdge, changeEdge }) {
+  const related = edges.filter(e => e.source === node.id);
+  return (
+    <div>
+      <input value={node.data.speaker} onChange={e => updateNode(node.id, 'speaker', e.target.value)} placeholder="Speaker" />
+      <textarea rows="3" value={node.data.text} onChange={e => updateNode(node.id, 'text', e.target.value)} placeholder="Text" />
+      <h4>Choices</h4>
+      {related.map(e => (
+        <div key={e.id} style={{ border: '1px solid #ccc', padding: '4px', marginBottom: '4px' }}>
+          <input value={e.label} onChange={ev => changeEdge(e.id, { label: ev.target.value })} placeholder="Choice text" />
+          <select value={e.target} onChange={ev => changeEdge(e.id, { target: ev.target.value })}>
+            {nodes.map(n => (
+              <option key={n.id} value={n.id}>{n.id}</option>
+            ))}
+          </select>
+          <button onClick={() => removeEdge(e.id)}>x</button>
+        </div>
+      ))}
+      <button onClick={() => addChoice(node.id)}>Add Choice</button>
+    </div>
+  );
+}
+
+function App() {
+  const [nodes, setNodes, onNodesChange] = useNodesState([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+  const [selected, setSelected] = React.useState(null);
+
+  React.useEffect(() => {
+    fetch('data/dialog.json').then(r => r.json()).then(data => {
+      const [n, e] = scriptToFlow(data);
+      setNodes(n);
+      setEdges(e);
+    });
+  }, []);
+
+  const onConnect = React.useCallback(params => setEdges(eds => addEdge({ ...params, label: '' }, eds)), []);
+
+  const updateNode = (id, field, value) => setNodes(ns => ns.map(n => n.id === id ? { ...n, data: { ...n.data, [field]: value } } : n));
+
+  const addChoice = sourceId => setEdges(eds => [...eds, { id: `e${eds.length}`, source: sourceId, target: sourceId, label: 'choice' }]);
+
+  const removeEdge = id => setEdges(eds => eds.filter(e => e.id !== id));
+
+  const changeEdge = (id, data) => setEdges(eds => eds.map(e => e.id === id ? { ...e, ...data } : e));
+
+  const addNodeButton = () => {
+    const id = `node${nodes.length + 1}`;
+    setNodes(ns => [...ns, { id, position: { x: 50 * ns.length, y: 50 * ns.length }, data: { speaker: '', text: '' } }]);
+  };
+
+  React.useEffect(() => {
+    const ok = validate(nodes, edges, 'start');
+    document.getElementById('validation').textContent = ok ? 'Valid path exists' : 'Dialogue has no end path';
+  }, [nodes, edges]);
+
+  const saveJson = () => {
+    const script = flowToScript(nodes, edges);
+    const blob = new Blob([JSON.stringify(script, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'dialog.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  React.useEffect(() => {
+    document.getElementById('add-node').onclick = addNodeButton;
+    document.getElementById('save-json').onclick = saveJson;
+  }, [nodes, edges]);
+
+  return (
+    <ReactFlowProvider>
+      <ReactFlowComponent
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onConnect={onConnect}
+        onNodeClick={(e, node) => setSelected(node)}
+        fitView
+      >
+        <MiniMap />
+        <Controls />
+        <Background />
+      </ReactFlowComponent>
+      {selected && (
+        <NodeEditor
+          node={selected}
+          nodes={nodes}
+          edges={edges}
+          updateNode={updateNode}
+          addChoice={addChoice}
+          removeEdge={removeEdge}
+          changeEdge={changeEdge}
+        />
+      )}
+    </ReactFlowProvider>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/index.html
+++ b/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Dialog Editor</title>
+  <link rel="stylesheet" href="https://unpkg.com/reactflow@11.11.4/dist/style.css" />
+  <style>
+    html, body, #root { margin: 0; padding: 0; width: 100%; height: 100%; }
+    #sidebar { position: absolute; right: 0; top: 0; width: 260px; background: #f8f8f8; height: 100%; overflow-y: auto; padding: 10px; box-sizing: border-box; }
+    #editor input, #editor textarea, #editor select { width: 100%; box-sizing: border-box; margin-bottom: 6px; }
+    #reactflow { width: calc(100% - 260px); height: 100%; }
+  </style>
+</head>
+<body>
+  <div id="reactflow"></div>
+  <div id="sidebar">
+    <h3>Edit Node</h3>
+    <div id="editor"></div>
+    <div id="validation" style="margin-top:10px;font-weight:bold;"></div>
+    <button id="add-node">Add Node</button>
+    <button id="save-json">Download JSON</button>
+  </div>
+
+  <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script src="https://unpkg.com/reactflow@11.11.4/dist/umd/index.js"></script>
+  <script type="text/babel" src="editor.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add sample dialog JSON data
- add React Flow-based editor
- add simple HTML frontend and usage notes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6875a8537734832b979046c4b08cc449