### PR TITLE
Add custom node display and sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/src/DialogNode.jsx
+++ b/src/DialogNode.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Handle, Position } from 'reactflow';
+
+export default function DialogNode({ id, data }) {
+  const text = data.text || '';
+  const truncated = text.length > 60 ? text.slice(0, 57) + '...' : text;
+
+  return (
+    <div style={{ padding: 10, border: '1px solid #555', background: '#fff', borderRadius: 4, minWidth: 160 }}>
+      <Handle type="target" position={Position.Top} />
+      <div style={{ fontWeight: 'bold' }}>{id}</div>
+      <div style={{ fontSize: 12, marginTop: 4 }}>{truncated}</div>
+      <Handle type="source" position={Position.Bottom} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `.gitignore` for build artifacts
- show node titles and truncated dialogue via new `DialogNode` component
- restructure `App.jsx` to use sidebar panel and custom nodes

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6875ae32d1f4832b8747d2b1ef245d68